### PR TITLE
Track query reference refactor

### DIFF
--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -325,7 +325,7 @@ module.exports = (function () {
 
 				track.Parsed_Link = sb.WebUtils.parseVideoLink(track.Video_Type, track.Link);
 
-				track.Favourites = track.Fan.map(i => i.ID);
+				track.Favourites = track.Fan?.length ?? 0;
 				track.Authors = track.Author.map(i => i.ID);
 				track.Tags = track.Tag.map(i => i.Name);
 				track.Aliases = track.Alias.map(i => i.Name);

--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -250,8 +250,8 @@ module.exports = (function () {
 					.reference({
 						fromTable: "Track",
 						referenceTable: "Track_Relationship",
-						referenceFieldSource: "Track_From",
-						referenceFieldTarget: "Track_To",
+						referenceFieldSource: "Track_To",
+						referenceFieldTarget: "Track_From",
 						targetTable: "Track",
 						targetAlias: "Youtube_Reupload",
 						collapseOn: "Track_ID",

--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -253,10 +253,11 @@ module.exports = (function () {
 						referenceFieldSource: "Track_From",
 						referenceFieldTarget: "Track_To",
 						targetTable: "Track",
-						condition: "Video_Type = 1 AND Available = 1",
 						targetAlias: "Youtube_Reupload",
 						collapseOn: "Track_ID",
-						fields: ["Reupload_ID"]
+						fields: ["Reupload_ID"],
+						referenceCondition: "Relationship = 'Reupload of'",
+						targetCodition: "Video_Type = 1 AND Available = 1"
 					})
 				);
 			}

--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -269,7 +269,7 @@ module.exports = (function () {
 				rs.select("Track.ID AS Track_ID")
 					.select("Tag.Name AS Tag_Name")
 					.select("Author.ID AS Author_ID", "Author.Name AS Author_Name")
-					.select("User_Alias.ID AS User_Alias_ID")
+					.select("Fan.ID AS Fan_ID")
 					.select("Alias.Name AS Alias_Name")
 					.reference({
 						sourceTable: "Track",
@@ -292,7 +292,7 @@ module.exports = (function () {
 						targetTable: "User_Alias",
 						referenceTable: "User_Favourite",
 						collapseOn: "Track_ID",
-						fields: ["User_Alias_ID"]
+						fields: ["Fan_ID"]
 					})
 					.reference({
 						sourceTable: "Track",

--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -335,10 +335,10 @@ module.exports = (function () {
 
 				if (targetUserID !== null) {
 					if (!track.Fans) {
-						track.Is_Favourite = false;
+						track.Is_Favourite = null;
 					}
 					else {
-						track.Is_Favourite = track.Favourites.includes(targetUserID);
+						track.Is_Favourite = track.Fan.includes(targetUserID);
 					}
 				}
 			}

--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -286,7 +286,7 @@ module.exports = (function () {
 						fields: ["Author_ID", "Author_Name"]
 					})
 					.reference({
-						alias: "Fans",
+						alias: "Fan",
 						sourceTable: "Track",
 						targetDatabase: "chat_data",
 						targetTable: "User_Alias",
@@ -301,7 +301,7 @@ module.exports = (function () {
 						collapseOn: "Track_ID",
 						fields: ["Alias_Name"],
 			            condition: "Alias.Target_Table = 'Track'"
-					})
+					});
 
 				for (const query of queries) {
 					query(rs);
@@ -325,36 +325,22 @@ module.exports = (function () {
 
 				track.Parsed_Link = sb.WebUtils.parseVideoLink(track.Video_Type, track.Link);
 
-				track.Favourites = track.Fans.map(i => i.User_Alias)
-
-				const uniqueFavourites = track.Fans?.split(",").filter((i, ind, arr) => ind === arr.indexOf(i));
-				track.Favourites = uniqueFavourites?.length ?? 0;
+				track.Favourites = track.Fan.map(i => i.ID);
+				track.Authors = track.Author.map(i => i.ID);
+				track.Tags = track.Tag.map(i => i.Name);
+				track.Aliases = track.Alias.map(i => i.Name);
+				track.Youtube_Reuploads = (track.Youtube_Reupload)
+					? track.Youtube_Reupload.map(i => i.Reupload_ID)
+					: null;
 
 				if (targetUserID !== null) {
 					if (!track.Fans) {
 						track.Is_Favourite = false;
 					}
 					else {
-						track.Is_Favourite = track.Fans.split(",").map(Number).includes(targetUserID);
+						track.Is_Favourite = track.Favourites.includes(targetUserID);
 					}
 				}
-
-				// @todo Remove these filters and make it so the above recordset uses reference table methods when they're implemented
-				track.Authors = (track.Authors)
-					? track.Authors.split(",").map(Number).filter((i, ind, arr) => arr.indexOf(i) === ind)
-					: [];
-
-				track.Tags = (track.Tags)
-					? track.Tags.split(",").map(Number).filter((i, ind, arr) => arr.indexOf(i) === ind)
-					: [];
-
-				track.Youtube_Reuploads = (track.Youtube_Reuploads)
-					? track.Youtube_Reuploads.split(",").map(Number).filter((i, ind, arr) => arr.indexOf(i) === ind)
-					: [];
-
-				track.Aliases = (track.Aliases)
-					? track.Aliases.split(",")
-					: [];
 			}
 
 			return data;

--- a/modules/track/track.js
+++ b/modules/track/track.js
@@ -286,7 +286,7 @@ module.exports = (function () {
 						fields: ["Author_ID", "Author_Name"]
 					})
 					.reference({
-						alias: "Fan",
+						targetAlias: "Fan",
 						sourceTable: "Track",
 						targetDatabase: "chat_data",
 						targetTable: "User_Alias",


### PR DESCRIPTION
Refactors a slew of `leftJoin()` query builder calls into `reference()` ones. goes hand in hand with `supi-core` refactor/finish-up of the method.