### PR TITLE
Check if there was no User found (userData = null)

### DIFF
--- a/routes/api/data/suggestion.js
+++ b/routes/api/data/suggestion.js
@@ -15,7 +15,7 @@ module.exports = (function () {
 		let userID = null;
 		if (rawUserID || userName) {
 			const userData = await sb.User.get(Number(rawUserID) || userName);
-			userID = userData.ID;
+			userID = userData?.ID;
 		}
 
 		return userID;


### PR DESCRIPTION
This will fix https://supinic.com/api/data/suggestion/list?userID=null or https://supinic.com/api/data/suggestion/list?userName=ahsdakshdakdhasdsgdagdaudgs to not throw a 500 status anymore.

I guess that you might wanna actually do a `sb.WebUtils.apiFail` and tell that there was nothing found with that query, but thats up to you :)

**EDIT:** 
Basically every endpoint at `/api/data/suggestion` that uses the `fetchUserID` function will result in the same 500 status.