### PR TITLE
Check if there was no User found (userData = null)

### DIFF
--- a/routes/api/data/suggestion.js
+++ b/routes/api/data/suggestion.js
@@ -139,12 +139,7 @@ module.exports = (function () {
 	Router.get("/list", async (req, res) => {
 		const { category, status, userID: rawUserID, userName } = req.query;
 
-		let userID = null;
-		if (rawUserID || userName) {
-			const userData = await sb.User.get(Number(rawUserID) || userName);
-			userID = userData.ID;
-		}
-
+		const userID = await fetchUserID(req);
 		const data = await Suggestion.list({ category, status, userID });
 		return sb.WebUtils.apiSuccess(res, data);
 	});

--- a/routes/api/data/suggestion.js
+++ b/routes/api/data/suggestion.js
@@ -15,7 +15,7 @@ module.exports = (function () {
 		let userID = null;
 		if (rawUserID || userName) {
 			const userData = await sb.User.get(Number(rawUserID) || userName);
-			userID = userData.ID;
+			userID = userData?.ID;
 		}
 
 		return userID;

--- a/routes/api/data/suggestion.js
+++ b/routes/api/data/suggestion.js
@@ -137,7 +137,7 @@ module.exports = (function () {
 	 * @apiSuccess {string} [notes]
 	 **/
 	Router.get("/list", async (req, res) => {
-		const { category, status, userID: rawUserID, userName } = req.query;
+		const { category, status } = req.query;
 
 		const userID = await fetchUserID(req);
 		const data = await Suggestion.list({ category, status, userID });

--- a/routes/api/track/alias.js
+++ b/routes/api/track/alias.js
@@ -67,7 +67,7 @@ module.exports = (function () {
 	 * If alias is not provided<br>
 	 * If the record table.tableID does not exist<br>
 	 * If the alias already exists for record table.tableID
-	 * @apiError {401} Unathorized If session timed out<br>
+	 * @apiError {401} Unauthorized If session timed out<br>
 	 * If not logged in - unauthorized
 	 */
 	Router.post("/", async (req, res) => {
@@ -111,7 +111,7 @@ module.exports = (function () {
 	 * If alias is not provided<br>
 	 * If the record table.tableID does not exist<br>
 	 * If the alias already exists for record table.tableID
-	 * @apiError {401} Unathorized If session timed out<br>
+	 * @apiError {401} Unauthorized If session timed out<br>
 	 * If not logged in - unauthorized
 	 */
 	Router.delete("/", async (req, res) => {


### PR DESCRIPTION
This will fix any endpoint at `/api/data/suggestion` that uses the `fetchUserID` function to not throw a 500 status anymore.

I guess that you might wanna actually do a `sb.WebUtils.apiFail` and tell that there was nothing found with that query, but thats up to you :)