### PR TITLE
corrected POST Reminder API endpoint returning 504

### DIFF
--- a/routes/api/bot/reminder.js
+++ b/routes/api/bot/reminder.js
@@ -164,7 +164,7 @@ module.exports = (function () {
 					invocation: "remind",
 					platform: "twitch",
 					channel: null,
-					user: userData.Name,
+					user: username,
 					arguments: `${username} ${reminderText} ${privateParameter}` ,
 					skipGlobalBan: "false"
 				}
@@ -177,7 +177,14 @@ module.exports = (function () {
 			});
 		}
 
-		const { result } = response.body.data;
+		const { data, error } = response.body;
+		if (!data || response.statusCode !== 200) {
+			return sb.WebUtils.apiFail(res, response.statusCode, {
+				reply: error?.message
+			});
+		}
+
+		const { result } = data;
 		if (result.success === false) {
 			return sb.WebUtils.apiFail(res, 400, {
 				reply: result.reply


### PR DESCRIPTION
In the last commit to this file (407e73cc629a87a9cd591399efb8f7775b6609d4), we removed the `userData` object, thus it is no longer available.
Therefore, the API returned with an error message `"userData is not defined"`.


This PR should fix that problem, although:

While locally testing I noticed, that if e.g. an invalid user was provided, `response.body.data` was null, therefore I added an check if thats the case. I'm not sure about how I handle that case (returning error.message), so tell me if I should change it. 


Also, I got an error for the `remind` command:
`sb.Error: Cannot set row value - column "Type" does not exist`

Looking at the `supi-db-init` repo => shared/definitions/chat_data/Reminder.sql I can't see the `Type` column either.
I suppose that this might only be an issue on my side, and that the `supi-db-init` repo has just not yet been updated.